### PR TITLE
翻译了mentoring and recruiting 中 《university and community》一文的引言部分。

### DIFF
--- a/mentoringrecruiting/zh_CN_KevinOttens.tex
+++ b/mentoringrecruiting/zh_CN_KevinOttens.tex
@@ -1,0 +1,141 @@
+\chapterwithauthor{凯文·欧登}{大学和社区}
+
+\authorbio{凯文·欧登是KDE社区的元老级黑客。
+他对KDE平台的重大贡献，集中在API设计和框架搭建上。
+2007年毕业，他得到了计算机科学方面的博士学位，这让他主要从事本体工程（ontologies engineering）和多智能体系统（multi-agent systems）的工作。
+凯文在KDBA的工作包括KDE周边的研究项目。
+他一直生活在图卢兹，并在他以前的大学做兼职教师。
+}
+
+\section*{引言}
+自由文化社区几乎都是本志愿者所驱动的。
+这些人中，大部分是在大学就加入社区的。
+有这么几点站得住脚的理由，支持你从事这样有趣的冒险：
+年轻，精力旺盛，有好奇心，也许还想去改变世界。
+这些在志愿工作中是非常必要的。
+
+但是同时作为一个学生，是不应该花费大量时间在自由文化社区上的。
+因为确实，这些社区相当大，而且很难交流。
+
+这里出现了个可怕的问题：自由文化社区对下一代天才贡献者的招募失败了么（因为他们拒绝主动向大学扩张）？
+那是个有意义的问题，我们一直试图在社区的软件产品（也就是KDE）的环境下探索这个问题。
+在此文中，我们主要讨论几个在寻找问题答案时，没有被预见，但是必须解决的方面。
+
+\section*{与当地的大学建立联系}
+Really, it all starts by reaching out to the students themselves, and for that,
+the best way is still to get to their universities, trying to show them how
+welcoming Free Culture communities can be. To that effect, we built a
+relationship with the Paul Sabatier University in Toulouse -- more precisely one
+of its courses of study named IUP ISI which focused on software engineering.
+
+The IUP ISI was very oriented toward ``hands on'' knowledge, and as such had a
+pre-existing program for student projects. A particularly interesting point of
+that program is the fact that students work in teams mixing students from
+different promotions. Third year and fourth year students get to collaborate on
+a common goal, which usually leads to teams of seven to ten students.
+
+The first year of our experiment we hooked up with that program, proposing new
+topics for the projects, focusing on software developed within the KDE
+community. Henri Massié, director of the course of study, has been very
+welcoming to the idea, and let us put the experiment in place. For that first
+year, we were allocated two slots for KDE related software projects.
+
+To quickly build trust, we decided that year to provide a few guarantees
+regarding the work of the students:
+\begin{itemize}
+  \item to help the teachers have confidence in the topics covered: the chosen
+projects were close to the topics taught at the IUP ISI (that is why we
+targeted a UML modeling tool and a project management tool for that year);
+  \item to give maximum visibility to the teachers: we provided them a server on
+which the student production was regularly built and remotely accessible for
+testing purpose;
+  \item to ease the engagement of the students with the community: the
+maintainers of the projects were appointed to play a ``customer'' role thus
+pushing requirements to the students and helping them find their way in the
+ramifications of the community;
+  \item finally, to get the students going, we introduced a short course on how
+to develop with Qt and the frameworks produced by KDE;
+\end{itemize}
+
+At the time of this writing, we have been through five years of such projects.
+Small adjustments to the organization have been done here and there, but most of
+the ideas behind it stayed the same. Most of the changes made were the result of
+more and more interest from the community willing to engage with students and
+of more and more freedom given to us in the topics we could cover in our
+projects.
+
+Moreover, throughout those years the director gave us continuous support and
+encouragement, effectively allocating more slots for Free Culture community
+projects, proving that our integration strategy was right: building trust very
+quickly is key to a relationship between a Free Culture community and a
+university.
+
+\section*{Realizing teaching is a two-way process}
+During those years of building bridges between the KDE community and the IUP ISI
+course of study, we ended up in teaching positions to support the students in
+their project related tasks. When you have never taught a classroom
+full of students, you might still have this image of yourself sitting in a
+classroom a few years ago. Indeed, most teachers were students once... sometimes
+not even the type of very disciplined or attentive students. You were likely
+having this feeling of drinking from a firehose: a teacher entering a room,
+getting in front of the students and delivering knowledge to you.
+
+This stereotype is what most people keep in mind of their years as students and
+the first time they get in a teaching situation they want to reproduce that
+stereotype: coming with knowledge to deliver.
+
+The good news is that nothing could be further from the truth than this
+stereotype. The bad news is that if you try to reproduce it, you are very likely
+to scare your students away and face nothing else than lack of motivation on
+their side to engage with the community. The image you give of yourself is the
+very first thing they will remember of the community: the first time you get in
+the classroom, to them \emph{you are} the community!
+
+Not falling into the trap of this stereotype requires you to step back a bit and to realize what teaching is really about. It is not a one way process where one
+delivers knowledge to students. We came to the conclusion that it is instead a
+two-way process: you get to create a symbiotic relationship with your student.
+Both the students and the teacher have to leave the classroom with new
+knowledge. You get to deliver your expertise of course -- but to do so efficiently
+you have to adapt to the students' frame of reference all the time. It is a very
+humbling work.
+
+Realizing that fact generates quite a few changes in the way you undertake
+your teaching:
+\begin{itemize}
+  \item You will have to understand the culture of your students. They probably
+have a fairly different background from you and you will have to adapt your
+discourse to them; for instance, the students we trained are all part of the so-called Y generation which exhibits fairly different traits regarding leadership, loyalty and trust than previous generations.
+  \item You will have to reassess your own expertise, since you will need to
+adapt your discourse to their culture. You will approach your own knowledge from
+very different angles than what you are used to, which will inevitably lead you
+to discoveries in fields you assumed you mastered.
+  \item Finally, you will have to build skills in presenting; a teaching
+position is really about getting out of your comfort zone to present your own
+knowledge while keeping it interesting and entertaining to your audience. It
+will make you a better presenter.
+\end{itemize}
+
+As such, you will become a better teacher. Also your goals of getting well
+trained students, and having students engage with a Free Culture community will
+be better fulfilled.
+
+\section*{Conclusion}
+At the end of the day why would you go through all the effort
+to build trust with a university and step outside of your comfort zone by
+improving your teaching? Well, it really boils down to the initial question we
+tried to answer:
+
+\emph{Do Free Culture communities fail to attract new contributors out of
+universities simply because of their inaction?}
+
+In our experience the answer is \emph{yes}. Through those five years of building
+up a relationship with the IUP ISI, we retained around two students per year on
+average. Some of them disappeared after a while, but some of them become very
+active contributors. The other ones still keep some nostalgia of that period of
+their life and keep advocating even though they do not contribute directly. And
+right now we have a local KDE team which managed to efficiently organize a two
+day conference for our latest release party.
+
+Of those former students, not a single one would have engaged with KDE without
+those university projects. We would have completely missed those talents.
+Luckily, we have not been inactive.


### PR DESCRIPTION
在free culture community 的翻译上遇上点问题。现翻译为“自由文化社区”，但是感觉“黑客社区”更合适的感觉。
